### PR TITLE
Fixing hint-panel reset bug

### DIFF
--- a/src/app/pages/Landing.tsx
+++ b/src/app/pages/Landing.tsx
@@ -72,12 +72,14 @@ const Landing = () => {
   const [guess, setGuess] = useState("");
   const [isWon, setWon] = useState(false);
   const [isDropdownFocused, setDropdownFocused] = useState(false);
+  const [isAnswerRevealed, setIsAnswerRevealed] = useState(false);
 
   const handleReset = () => {
     setWon(false);
     setGuess("");
     setDropdown([]);
     setDropdownFocused(false);
+    setIsAnswerRevealed(false);
     // reset pokemon
     setId(getRandomId);
     // reset incorrect count, to reset hints
@@ -111,6 +113,10 @@ const Landing = () => {
 
   const handleDropdownFocused = (newDropdownBool: boolean) => {
     setDropdownFocused(newDropdownBool);
+  };
+
+  const handleAnswerRevealed = () => {
+    setIsAnswerRevealed(true);
   };
 
   // on first load-in, fetch all Pokémon names for use in search bar suggestions
@@ -222,7 +228,9 @@ const Landing = () => {
             count={incorrectCount}
             type1={type1_details}
             type2={type2_details}
+            isAnswerRevealed={isAnswerRevealed}
             handleReset={handleReset}
+            handleAnswerRevealed={handleAnswerRevealed}
           ></HintPanel>
           {/* <SettingsButton></SettingsButton>
           <PokeBall></PokeBall> */}

--- a/src/components/HintPanel.tsx
+++ b/src/components/HintPanel.tsx
@@ -1,6 +1,6 @@
 import { z } from "zod";
 import { Pokemon, PokemonTypeSprite } from "../lib/schema/index";
-import { useRef, useState } from "react";
+import { useRef } from "react";
 import { isIE, isSafari } from "react-device-detect";
 
 export const HintPanel = ({
@@ -8,13 +8,17 @@ export const HintPanel = ({
   count,
   type1,
   type2,
+  isAnswerRevealed,
   handleReset,
+  handleAnswerRevealed,
 }: {
   data: z.infer<typeof Pokemon> | undefined;
   count: number;
   type1: z.infer<typeof PokemonTypeSprite> | undefined;
   type2: z.infer<typeof PokemonTypeSprite> | undefined;
+  isAnswerRevealed: boolean;
   handleReset: () => void;
+  handleAnswerRevealed: () => void;
 }) => {
   let weightUnlocked = false;
   let typeUnlocked = false;
@@ -22,18 +26,8 @@ export const HintPanel = ({
   // let abilitiesUnlocked = false;
 
   const hintRef = useRef<HTMLDivElement | null>(null);
-  const [isAnswerRevealed, setIsAnswerRevealed] = useState(false);
-
-  const handleAnswerRevealed = () => {
-    setIsAnswerRevealed(true);
-
-    setTimeout(() => {
-      scrollToHint();
-    }, 100);
-  };
 
   const handleNewGame = () => {
-    setIsAnswerRevealed(false);
     handleReset();
   };
 
@@ -143,7 +137,12 @@ export const HintPanel = ({
           <div className="flex justify-center gap-x-14 xl:gap-x-18 text-[1.5rem] mt-6 mb-12">
             <button
               className="cursor-pointer px-2 py-4 max-w-[20%] py-4 bg-[#fd6b70] rounded-xl"
-              onClick={handleAnswerRevealed}
+              onClick={() => {
+                handleAnswerRevealed();
+                setTimeout(() => {
+                  scrollToHint();
+                }, 100);
+              }}
             >
               Reveal Answer
             </button>

--- a/src/components/HintPanel.tsx
+++ b/src/components/HintPanel.tsx
@@ -19,7 +19,7 @@ export const HintPanel = ({
   let weightUnlocked = false;
   let typeUnlocked = false;
   let spriteUnlocked = false;
-  let abilitiesUnlocked = false;
+  // let abilitiesUnlocked = false;
 
   const hintRef = useRef<HTMLDivElement | null>(null);
   const [isAnswerRevealed, setIsAnswerRevealed] = useState(false);


### PR DESCRIPTION
Encountered bug upon generating new game, where isAnswerRevealed variable isn't reset, so fixed by lifting state up.